### PR TITLE
Bump ember-cli-deploy-revision-data to 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ember-cli-deploy-display-revisions": "0.1.2",
     "ember-cli-deploy-gzip": "~0.2.1",
     "ember-cli-deploy-manifest": "~0.1.1",
-    "ember-cli-deploy-revision-data": "0.1.1",
+    "ember-cli-deploy-revision-data": "0.2.2",
     "ember-cli-deploy-s3": "~0.2.1",
     "ember-cli-deploy-s3-index": "~0.3.0"
   },


### PR DESCRIPTION
`ember-cli-deploy-revision-data` was updated to handle environments with partial git info.
